### PR TITLE
fix: incorrect blog Links and japanese-english

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -49,14 +49,14 @@ export default function Navbar() {
                                     </li>
                                     <li>
                                         <a
-                                            href="https://blog.floorp.app/category/notice/"
+                                            href="https://blog.floorp.app/categories/notice/"
                                             target="_blank"
                                         >
                                             {t("navbar.news")}
                                         </a>
                                     </li>
                                     <li>
-                                        <a href="https://blog.floorp.app/releases/">
+                                        <a href="https://blog.floorp.app/categories/release/">
                                             {t("navbar.releaseNotes")}
                                         </a>
                                     </li>
@@ -98,14 +98,14 @@ export default function Navbar() {
                                     </li>
                                     <li>
                                         <a
-                                            href="https://blog.floorp.app/category/notice/"
+                                            href="https://blog.floorp.app/categories/notice/"
                                             target="_blank"
                                         >
                                             {t("navbar.news")}
                                         </a>
                                     </li>
                                     <li>
-                                        <a href="https://blog.floorp.app/releases/">
+                                        <a href="https://blog.floorp.app/categories/release/">
                                             {t("navbar.releaseNotes")}
                                         </a>
                                     </li>

--- a/public/locales/en-US/common.json
+++ b/public/locales/en-US/common.json
@@ -108,7 +108,7 @@
         "resources": "Resources",
         "docs": "Floorp Docs",
         "blog": "Floorp Blog",
-        "sns": "SNS",
+        "sns": "Connect with us",
         "legal": "Legal",
         "terms": "Terms of use",
         "privacy": "Privacy policy",


### PR DESCRIPTION
- Floorp Blog 関連の URL が一部 404 になっていた問題を修正
- "SNS" は和製英語なので英語版では使用しないように変更