### PR TITLE
fix: various fixes

### DIFF
--- a/components/DownloadSection.tsx
+++ b/components/DownloadSection.tsx
@@ -243,7 +243,7 @@ export function DownloadSection() {
                             <div className="card-actions flex-col gap-2">
                                 <a
                                     href={getLinuxDownloadUrl()}
-                                    className={`btn btn-primary w-full ${
+                                    className={`btn btn-primary btn-lg w-full ${
                                         isDownloadDisabled ? "btn-disabled" : ""
                                     }`}
                                 >

--- a/components/DownloadSection.tsx
+++ b/components/DownloadSection.tsx
@@ -314,7 +314,7 @@ export function DownloadSection() {
 
                             <div className="flex flex-col gap-4 mt-6">
                                 <Link
-                                    href="https://blog.floorp.app/release"
+                                    href="https://blog.floorp.app/categories/release/"
                                     className="btn btn-outline flex items-center gap-2"
                                 >
                                     <FileText size={18} />

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -56,7 +56,7 @@ export default function Navbar() {
                                         </a>
                                     </li>
                                     <li>
-                                        <a href="https://blog.floorp.app/release/">
+                                        <a href="https://blog.floorp.app/categories/release/">
                                             {t("navbar.releaseNotes")}
                                         </a>
                                     </li>
@@ -98,14 +98,14 @@ export default function Navbar() {
                                     </li>
                                     <li>
                                         <a
-                                            href="https://blog.floorp.app/category/notice/"
+                                            href="https://blog.floorp.app/categories/notice/"
                                             target="_blank"
                                         >
                                             {t("navbar.news")}
                                         </a>
                                     </li>
                                     <li>
-                                        <a href="https://blog.floorp.app/release/">
+                                        <a href="https://blog.floorp.app/categories/release/">
                                             {t("navbar.releaseNotes")}
                                         </a>
                                     </li>

--- a/public/locales/en-US/common.json
+++ b/public/locales/en-US/common.json
@@ -109,7 +109,7 @@
         "resources": "Resources",
         "docs": "Floorp Docs",
         "blog": "Floorp Blog",
-        "sns": "SNS",
+        "sns": "Connect with us",
         "legal": "Legal",
         "terms": "Terms of use",
         "privacy": "Privacy policy",


### PR DESCRIPTION
fixes #13 
- Floorp Blog 関連の URL が一部 404 になっていた問題を修正
- "SNS" は和製英語なので英語版では使用しないように変更
- Linux 版ダウンロードボタンのサイズを Win/Mac と揃える (ポータブルと ARM は小さいまま)