### PR TITLE
fix(components): correct invalid docs urls

### DIFF
--- a/components/FeatureCard.tsx
+++ b/components/FeatureCard.tsx
@@ -63,7 +63,7 @@ export function FeatureCardSection() {
         {
             title: t("featureCards.browsing.title"),
             description: t("featureCards.browsing.description"),
-            linkUrl: "https://docs.floorp.app/docs/features/workspaces",
+            linkUrl: "https://docs.floorp.app/docs/features/how-to-use-workspaces",
             linkText: t("featureCards.browsing.linkText"),
             imageSrc: "/Workspaces.svg",
             imageAlt: "Workspaces Feature",
@@ -71,7 +71,7 @@ export function FeatureCardSection() {
         {
             title: t("featureCards.controls.title"),
             description: t("featureCards.controls.description"),
-            linkUrl: "https://docs.floorp.app/docs/features/panel-sidebar",
+            linkUrl: "https://docs.floorp.app/docs/features/how-to-use-gesture",
             linkText: t("featureCards.controls.linkText"),
             imageSrc: "/MouseGesture.svg",
             imageAlt: "Mouse Gesture Feature",


### PR DESCRIPTION
以下の PR と関連します:
https://github.com/Floorp-Projects/floorp-docs-neo/pull/107

- ワークスペースに関するドキュメントはすでに存在しますが、URL が誤っていたため正しいものに変更しました。
- 名前の一貫性のために、暫定的に追加したマウスジェスチャーに関するドキュメントは先頭に "how-to-use" が付きます。
- ブログなど、ドキュメント以外の無効なリンクは #12 で修正を試みています。