### PR TITLE
fix: update github sponsors link

### DIFF
--- a/src/components/AboutUsSection.tsx
+++ b/src/components/AboutUsSection.tsx
@@ -62,7 +62,7 @@ export function AboutUsSection() {
 
                   <div className="mt-4">
                     <a
-                      href="https://github.com/sponsors/surapunoyousei"
+                      href="https://github.com/sponsors/Ryosuke-Asano"
                       target="_blank"
                       rel="noopener noreferrer"
                       className="inline-flex items-center gap-2 text-primary hover:underline group"


### PR DESCRIPTION
Change the sponsor URL in src/components/AboutUsSection.tsx from the 'surapunoyousei' account to the 'Ryosuke-Asano' GitHub Sponsors profile so the link points to the correct recipient

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the GitHub Sponsors donation link to direct to the correct recipient.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Floorp-Projects/web-v3/pull/23)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->