### PR TITLE
fix: bump copyright year to 2026

### DIFF
--- a/public/locales/en-US/common.json
+++ b/public/locales/en-US/common.json
@@ -186,6 +186,6 @@
         "terms": "Terms of use",
         "privacy": "Privacy policy",
         "license": "LICENSE",
-        "copyright": "© 2025 Floorp Projects And Collaborate With Ablaze. All rights reserved."
+        "copyright": "© 2026 Floorp Projects And Collaborate With Ablaze. All rights reserved."
     }
 }

--- a/public/locales/ja-JP/common.json
+++ b/public/locales/ja-JP/common.json
@@ -186,6 +186,6 @@
         "terms": "利用規約",
         "privacy": "プライバシーポリシー",
         "license": "ライセンス",
-        "copyright": "© 2025 Floorp プロジェクト・Ablaze との協力のもと。すべての権利を保有。"
+        "copyright": "© 2026 Floorp プロジェクト・Ablaze との協力のもと。すべての権利を保有。"
     }
 }


### PR DESCRIPTION
Update copyright year from 2025 to 2026 in locale files (public/locales/en-US/common.json and public/locales/ja-JP/common.json).